### PR TITLE
Handle errors emitted by subscribers to OnTrackerLogUpdate during load

### DIFF
--- a/ItemChanger/SaveData.cs
+++ b/ItemChanger/SaveData.cs
@@ -98,7 +98,14 @@ public class SaveData
             using var reader = new Json.JsonTextReader(file);
             var ser = Json.JsonSerializer.CreateDefault(jsonSettings);
             current = ser.Deserialize<SaveData>(reader);
-            OnTrackerLogUpdate?.Invoke(current!.TrackerLog);
+            try
+            {
+                OnTrackerLogUpdate?.Invoke(current!.TrackerLog);
+            }
+            catch (System.Exception err)
+            {
+                ItemChangerPlugin.LogError($"Error running subscriber to SaveData.OnTrackerLogUpdate: {err}");
+            }
         }
         catch (IO.FileNotFoundException)
         {


### PR DESCRIPTION
I noticed working on another PR that there was no error handling during ItemChanger.SaveData.Load, but there was during AddToTrackerLog. I added the same error handling to Load to mimic that behavior.

If there's a reason to not do this, this part wasn't crucial; it was mostly just helpful during debugging.