### PR TITLE
Clear tracker log display when returning to the title screen

### DIFF
--- a/ItemChanger/ItemChangerPlugin.cs
+++ b/ItemChanger/ItemChangerPlugin.cs
@@ -2,6 +2,7 @@
 using Collections = System.Collections.Generic;
 using Bep = BepInEx;
 using HL = HarmonyLib;
+using UnityEngine.SceneManagement;
 
 namespace DDoor.ItemChanger;
 
@@ -54,6 +55,9 @@ internal class ItemChangerPlugin : Bep.BaseUnityPlugin
                     activePlacements[(loc.GetType(), loc.UniqueId)] = placedItem;
                 }
             };
+
+            SceneManager.sceneLoaded += SaveData.OnSceneLoaded;
+
             new HL.Harmony("deathsdoor.itemchanger").PatchAll();
             InitStatus = 1;
         }

--- a/ItemChanger/ItemChangerPlugin.cs
+++ b/ItemChanger/ItemChangerPlugin.cs
@@ -2,7 +2,7 @@
 using Collections = System.Collections.Generic;
 using Bep = BepInEx;
 using HL = HarmonyLib;
-using UnityEngine.SceneManagement;
+using USM = UnityEngine.SceneManagement;
 
 namespace DDoor.ItemChanger;
 
@@ -56,7 +56,7 @@ internal class ItemChangerPlugin : Bep.BaseUnityPlugin
                 }
             };
 
-            SceneManager.sceneLoaded += SaveData.OnSceneLoaded;
+            USM.SceneManager.sceneLoaded += SaveData.OnSceneLoaded;
 
             new HL.Harmony("deathsdoor.itemchanger").PatchAll();
             InitStatus = 1;

--- a/ItemChanger/SaveData.cs
+++ b/ItemChanger/SaveData.cs
@@ -4,6 +4,7 @@ using IO = System.IO;
 using Json = Newtonsoft.Json;
 using UE = UnityEngine;
 using HL = HarmonyLib;
+using UnityEngine.SceneManagement;
 
 namespace DDoor.ItemChanger;
 
@@ -110,6 +111,15 @@ public class SaveData
             current = null;
             OnTrackerLogUpdate?.Invoke(null);
             ItemChangerPlugin.LogError($"Error loading save data for save ID {saveId}: {err.ToString()}");
+        }
+    }
+
+    public static void OnSceneLoaded(Scene scene, LoadSceneMode _)
+    {
+        if (scene.name == "TitleScreen")
+        {
+            // If loading into the TitleScreen, clear the TrackerLog so that RecentItemsDisplay does not keep showing the items from the previous play.
+            OnTrackerLogUpdate?.Invoke(null);
         }
     }
 

--- a/ItemChanger/SaveData.cs
+++ b/ItemChanger/SaveData.cs
@@ -4,7 +4,7 @@ using IO = System.IO;
 using Json = Newtonsoft.Json;
 using UE = UnityEngine;
 using HL = HarmonyLib;
-using UnityEngine.SceneManagement;
+using USM = UnityEngine.SceneManagement;
 
 namespace DDoor.ItemChanger;
 
@@ -114,7 +114,7 @@ public class SaveData
         }
     }
 
-    public static void OnSceneLoaded(Scene scene, LoadSceneMode _)
+    public static void OnSceneLoaded(USM.Scene scene, USM.LoadSceneMode _)
     {
         if (scene.name == "TitleScreen")
         {


### PR DESCRIPTION
When returning to the main menu, current behavior in conjunction with RecentItemsDisplay keeps the items received showing in the upper right on the title screen. This change watches for the Title Screen to load and issues `OnTrackerLogUpdate?.Invoke(null)` to clear the displayed items until a save slot is loaded.

RecentItemsDisplay has a small bug that appears when used with this method (as well as other reloads/new files). https://github.com/dpinela/DeathsDoor.RecentItemsDisplay/pull/1 addresses that bug.